### PR TITLE
Add BuiltWithDot.Net badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![Build (master)](https://img.shields.io/github/workflow/status/NetFabric/NetFabric.Assertive/.NET%20Core/master.svg?style=flat-square&logo=github)](https://github.com/NetFabric/NetFabric.Assertive/actions)
 [![Coverage](https://img.shields.io/coveralls/github/NetFabric/NetFabric.Assertive/master?style=flat-square&logo=coveralls)](https://coveralls.io/github/NetFabric/NetFabric.Assertive)
 [![NuGet Version](https://img.shields.io/nuget/v/NetFabric.Assertive.svg?style=flat-square&logo=nuget)](https://www.nuget.org/packages/NetFabric.Assertive/)
-[![NuGet Downloads](https://img.shields.io/nuget/dt/NetFabric.Assertive.svg?style=flat-square&logo=nuget)](https://www.nuget.org/packages/NetFabric.Assertive/) 
+[![NuGet Downloads](https://img.shields.io/nuget/dt/NetFabric.Assertive.svg?style=flat-square&logo=nuget)](https://www.nuget.org/packages/NetFabric.Assertive/)
+[![BuiltWithDot.Net shield](https://builtwithdot.net/project/507/netfabric-assertive/badge)](https://builtwithdot.net/project/507/netfabric-assertive)
 
 # NetFabric.Assertive
 


### PR DESCRIPTION
Since NetFabric.Assertive is listed on BuiltWithDot.Net I've taken the liberty to raise a PR that adds the BuiltWithDot.Net badge for NetFabric.Assertive to the README.md file. This will help promote your project, BuiltWithDot.Net, all other .NET developers that have projects listed on the site, and the open-source .NET ecosystem in general. If you have any questions or concerns, please let me know. Your help is much appreciated!

Thanks, Corstiaan (creator of BuiltWithDot.Net)

PS If you don't want to add the badge, that's totally fine. Just close this PR. No hard feelings :-)